### PR TITLE
Feature/basedpyright

### DIFF
--- a/vim/dpp/hooks/lua/lsp.lua
+++ b/vim/dpp/hooks/lua/lsp.lua
@@ -531,7 +531,7 @@ vim.api.nvim_create_autocmd(
         callback = function(args)
             local client = vim.lsp.get_client_by_id(args.data.client_id)
             if client ~= nil and client.supports_method('textDocument/inlayHint') then
-                vim.lsp.inlay_hint.enable()
+                vim.lsp.inlay_hint.enable(false)
                 vim.api.nvim_set_hl(0, "LspInlayHint", { fg = 112, bg = 'White', italic = true })
             end
         end

--- a/vim/dpp/hooks/lua/lsp.lua
+++ b/vim/dpp/hooks/lua/lsp.lua
@@ -61,7 +61,7 @@ nvim_navic.setup({
         auto_attach = true,
         preference = {
             'pyright',
-            -- 'basedpyright',
+            'basedpyright',
         },
     },
     highlight = false,
@@ -202,11 +202,13 @@ local basedpyright_setting = {
             -- 診断のレベルを上書きする
             -- https://github.com/microsoft/pylance-release/blob/main/DIAGNOSTIC_SEVERITY_RULES.md
             diagnosticSeverityOverrides = {
-                reportGeneralTypeIssues = "none",
-                reportMissingTypeArgument = "none",
-                reportUnknownMemberType = "none",
-                reportUnknownVariableType = "none",
-                reportUnknownArgumentType = "none",
+                -- reportGeneralTypeIssues = "none",
+                -- reportMissingTypeArgument = "none",
+                -- reportUnknownMemberType = "none",
+                -- reportUnknownVariableType = "none",
+                -- reportUnknownArgumentType = "none",
+                -- reportPrivateLocalImportUseage = 'none',
+
             },
 
             exclude = {
@@ -245,8 +247,10 @@ local basedpyright_setting = {
             reportMissingTypeArgument = 'none',
             reportOptionalSubscript = 'none',
             reportOptionalMemberAccess = 'none',
-
-
+            reportPrivateLocalImportUseage = 'none',
+            reportUnknownMemberType = "none",
+            reportUnknownVariableType = "none",
+            reportUnknownArgumentType = "none",
 
             pylintPath = {
             },
@@ -404,9 +408,9 @@ local pylsp_setting = {
 }
 
 local servers = {
-    -- basedpyright = basedpyright_setting,
-    pyright = pyright_setting,
-    -- pylsp = pylsp_setting,
+    basedpyright = basedpyright_setting,
+    -- pyright = pyright_setting,
+    pylsp = pylsp_setting,
     -- mypy = {},
     -- flake8 = {},
     -- isort = {},
@@ -427,7 +431,7 @@ local servers = {
 
 mason_lspconfig.setup({
     ensure_installed = vim.tbl_keys(servers),
-    automatic_installation = false,
+    automatic_installation = true,
 })
 
 local opts = {
@@ -464,6 +468,8 @@ end
 
 mason_lspconfig.setup_handlers({
     function(server_name)
+        print('server_name!!')
+        print(server_name)
         local opts = {}
         if (server_name == 'pyright') then
             opts.root_dir = util.root_pattern('.venv')

--- a/vim/dpp/hooks/lua/lsp.lua
+++ b/vim/dpp/hooks/lua/lsp.lua
@@ -59,10 +59,10 @@ nvim_navic.setup({
     },
     lsp = {
         auto_attach = true,
-        -- preference = {
-        --     -- 'pyright',
-        --     'basedpyright',
-        -- },
+        preference = {
+            'pyright',
+            -- 'basedpyright',
+        },
     },
     highlight = false,
     separator = " > ",
@@ -159,15 +159,28 @@ print('venv_path')
 print(venv_path(filepath))
 
 local basedpyright_setting = {
+    -- include = {}
+    -- exclude = {}
+    -- strict = {}
+    -- extends = {}
+    -- defineConstant = {}
+    -- typeshedPaths = {}
+    -- stubPath = {}
+    -- venv_path = {}
+    -- venv = {}
+    -- verboserOutput = True
+    -- extraPaths = {}
+    -- pythonVersion = ''
+    --
+    python = {
+        pythonPath = python_path,
+        venvPath = venv_path(filepath),
+    },
     basedpyright = {
+        disableLanguageService = false,
+        disableOrganizeImports = false,
+        disableTaggedHints = false,
         analysis = {
-            --
-            -- inlayHints = {
-            --     functionReturnTypes = true,
-            --     variableTypes = true,
-            -- },
-
-            --
             autoImportCompletions = true,
 
             -- 事前定義された名前にもどついて検索パスを自動的に追加するか
@@ -175,6 +188,16 @@ local basedpyright_setting = {
 
             -- [openFilesOnly, workspace]
             diagnosticMode = "openFilesOnly",
+
+            -- default: Information [Error, Warning, Information, Trace]
+            -- logLevel = 'Warning',
+            logLevel = 'Trace',
+
+            inlayHints = {
+                variableTypes = true,
+                callArgumentNames = true,
+                functionReturnTypes = true,
+            },
 
             -- 診断のレベルを上書きする
             -- https://github.com/microsoft/pylance-release/blob/main/DIAGNOSTIC_SEVERITY_RULES.md
@@ -186,19 +209,32 @@ local basedpyright_setting = {
                 reportUnknownArgumentType = "none",
             },
 
+            exclude = {
+            },
+
             -- インポート解決のための追加検索パス指定
             extraPaths = {
             },
 
-            -- default: Information [Error, Warning, Information, Trace]
-            -- logLevel = 'Warning',
-            logLevel = 'Trace',
+            ignore = {
+            },
+
+            include = {
+            },
 
             -- カスタムタイプのstubファイルを含むディレクトリ指定 default: ./typings
-            -- stubPath = '',
+            stubPath = '',
 
             -- 型チェックの分析レベル default: off [off, basic, strict]
             typeCheckingMode = 'off',
+
+            --
+            -- typeshedPaths = '',
+
+            -- default: false
+            useLibraryCodeForTypes = true,
+
+
             reportMissingImports = 'none',
             reportMissingModuleSource = 'none',
             reportUnusedImport = 'none',
@@ -210,11 +246,7 @@ local basedpyright_setting = {
             reportOptionalSubscript = 'none',
             reportOptionalMemberAccess = 'none',
 
-            --
-            -- typeshedPaths = '',
 
-            -- default: false
-            useLibraryCodeForTypes = true,
 
             pylintPath = {
             },
@@ -373,8 +405,8 @@ local pylsp_setting = {
 
 local servers = {
     -- basedpyright = basedpyright_setting,
-    -- pyright = pyright_setting,
-    pylsp = pylsp_setting,
+    pyright = pyright_setting,
+    -- pylsp = pylsp_setting,
     -- mypy = {},
     -- flake8 = {},
     -- isort = {},
@@ -436,10 +468,10 @@ mason_lspconfig.setup_handlers({
         if (server_name == 'pyright') then
             opts.root_dir = util.root_pattern('.venv')
         end
-        if (server_name == 'pylsp') then
+        if (server_name == 'basedpyright') then
             opts.root_dir = util.root_pattern('.venv')
         end
-        if (server_name == 'basedpyright') then
+        if (server_name == 'pylsp') then
             opts.root_dir = util.root_pattern('.venv')
         end
         opts.on_attach = on_attach

--- a/vim/dpp/hooks/lua/lsp.lua
+++ b/vim/dpp/hooks/lua/lsp.lua
@@ -131,14 +131,14 @@ local config = {
 vim.diagnostic.config(config)
 
 local bufnr = vim.api.nvim_get_current_buf()
-print("bufnr")
-print(bufnr)
+-- print("bufnr")
+-- print(bufnr)
 local filepath = vim.api.nvim_buf_get_name(bufnr)
-print('filepath')
-print(filepath)
+-- print('filepath')
+-- print(filepath)
 local venv_path = util.root_pattern('.venv')
-print('venv_path')
-print(venv_path)
+-- print('venv_path')
+-- print(venv_path)
 local python_path = nil
 python_path = vim.g.python3_host_prog
 -- if (venv_path == nil) then
@@ -153,10 +153,10 @@ python_path = vim.g.python3_host_prog
 --         'python'
 --     )
 -- end
-print('python_path')
-print(python_path)
-print('venv_path')
-print(venv_path(filepath))
+-- print('python_path')
+-- print(python_path)
+-- print('venv_path')
+-- print(venv_path(filepath))
 
 local basedpyright_setting = {
     -- include = {}
@@ -197,18 +197,26 @@ local basedpyright_setting = {
                 variableTypes = true,
                 callArgumentNames = true,
                 functionReturnTypes = true,
+                genericTypes = true,
             },
 
             -- 診断のレベルを上書きする
             -- https://github.com/microsoft/pylance-release/blob/main/DIAGNOSTIC_SEVERITY_RULES.md
             diagnosticSeverityOverrides = {
-                -- reportGeneralTypeIssues = "none",
-                -- reportMissingTypeArgument = "none",
-                -- reportUnknownMemberType = "none",
-                -- reportUnknownVariableType = "none",
-                -- reportUnknownArgumentType = "none",
-                -- reportPrivateLocalImportUseage = 'none',
-
+                reportMissingImports = 'none',
+                reportMissingModuleSource = 'none',
+                reportUnusedImport = 'none',
+                reportUnusedVariable = 'none',
+                reportUnboundVariable = 'none',
+                reportUndefinedVariable = 'none',
+                reportGeneralTypeIssues = 'none',
+                reportMissingTypeArgument = 'none',
+                reportOptionalSubscript = 'none',
+                reportOptionalMemberAccess = 'none',
+                reportPrivateLocalImportUseage = 'none',
+                reportUnknownMemberType = "none",
+                reportUnknownVariableType = "none",
+                reportUnknownArgumentType = "none",
             },
 
             exclude = {
@@ -236,21 +244,6 @@ local basedpyright_setting = {
             -- default: false
             useLibraryCodeForTypes = true,
 
-
-            reportMissingImports = 'none',
-            reportMissingModuleSource = 'none',
-            reportUnusedImport = 'none',
-            reportUnusedVariable = 'none',
-            reportUnboundVariable = 'none',
-            reportUndefinedVariable = 'none',
-            reportGeneralTypeIssues = 'none',
-            reportMissingTypeArgument = 'none',
-            reportOptionalSubscript = 'none',
-            reportOptionalMemberAccess = 'none',
-            reportPrivateLocalImportUseage = 'none',
-            reportUnknownMemberType = "none",
-            reportUnknownVariableType = "none",
-            reportUnknownArgumentType = "none",
 
             pylintPath = {
             },
@@ -468,8 +461,8 @@ end
 
 mason_lspconfig.setup_handlers({
     function(server_name)
-        print('server_name!!')
-        print(server_name)
+        -- print('server_name!!')
+        -- print(server_name)
         local opts = {}
         if (server_name == 'pyright') then
             opts.root_dir = util.root_pattern('.venv')
@@ -531,17 +524,16 @@ vim.api.nvim_create_autocmd({
 
 vim.api.nvim_create_autocmd(
     {
-    'LspAttach',
+        'LspAttach',
     },
     {
-        group = diagnostic_hover_augroup_name,
+        group = vim.api.nvim_create_augroup('UserLspConfig', {}),
         callback = function(args)
-            local bufnr = args.buf
             local client = vim.lsp.get_client_by_id(args.data.client_id)
-            -- if client.supports_method("textDocument/inlayHint") then
-            --     vim.lsp.inlay_hint(bufnr, true)
-            -- end
-        end,
+            if client ~= nil and client.supports_method('textDocument/inlayHint') then
+                vim.lsp.inlay_hint.enable()
+            end
+        end
     }
 )
 

--- a/vim/dpp/hooks/lua/lsp.lua
+++ b/vim/dpp/hooks/lua/lsp.lua
@@ -532,8 +532,20 @@ vim.api.nvim_create_autocmd(
             local client = vim.lsp.get_client_by_id(args.data.client_id)
             if client ~= nil and client.supports_method('textDocument/inlayHint') then
                 vim.lsp.inlay_hint.enable()
+                vim.api.nvim_set_hl(0, "LspInlayHint", { fg = 112, bg = 'White', italic = true })
             end
         end
+    }
+)
+
+-- InlayHintの表示切り替え
+vim.api.nvim_create_user_command(
+    'ToggleInlayHint',
+    function(_)
+        vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
+    end,
+    {
+        nargs = 0,
     }
 )
 

--- a/vim/rc/dpp.lua
+++ b/vim/rc/dpp.lua
@@ -81,8 +81,12 @@ vim.cmd('syntax on')
 
 -- TODO
 vim.cmd('colorscheme codedark')
-vim.cmd('highlight LspDiagnosticsSignError ctermbg=None cterm=underline ctermfg=Red')
-vim.cmd('highlight LspDiagnosticsSignWarn  ctermbg=None cterm=underline ctermfg=Yellow')
-vim.cmd('highlight LspDiagnosticsSignHint  ctermbg=None cterm=underline ctermfg=LightBlue')
-vim.cmd('highlight LspDiagnosticsSignInfo  ctermbg=None cterm=underline ctermfg=White')
-vim.cmd('highlight CocInlayHint ctermbg=18 ctermfg=112 guibg=#cceeee guifg=#004400 cterm=italic gui=italic')
+-- vim.cmd('highlight LspDiagnosticsSignError ctermbg=None cterm=underline ctermfg=Red')
+-- vim.cmd('highlight LspDiagnosticsSignWarn  ctermbg=None cterm=underline ctermfg=Yellow')
+-- vim.cmd('highlight LspDiagnosticsSignHint  ctermbg=None cterm=underline ctermfg=LightBlue')
+-- vim.cmd('highlight LspDiagnosticsSignInfo  ctermbg=None cterm=underline ctermfg=White')
+vim.api.nvim_set_hl(0, 'LspDiagnosticsSignError', { fg = 'Red', bg = nil, underline = true })
+vim.api.nvim_set_hl(0, 'LspDiagnosticsSignWarn', { fg = 'Yellow', bg = nil, underline = true  })
+vim.api.nvim_set_hl(0, 'LspDiagnosticsSignHint', { fg = 'LightBlue', bg = nil, underline = true })
+vim.api.nvim_set_hl(0, 'LspDiagnosticsSignInfo', { fg = 'White', bg = nil, underline = true  })
+


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- `basedpyright`の設定を追加し、LSP設定を強化

- InlayHintのデフォルト設定を無効化し、表示切り替えコマンドを追加

- ハイライト設定を`vim.api.nvim_set_hl`を使用して更新

- LSPサーバーの自動インストールを有効化


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lsp.lua</strong><dd><code>`basedpyright`設定とInlayHintの改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vim/dpp/hooks/lua/lsp.lua

<li><code>basedpyright</code>の設定を追加し、LSP設定を強化<br> <li> InlayHintのデフォルト設定を無効化<br> <li> InlayHintの表示切り替えコマンドを追加<br> <li> LSPサーバーの自動インストールを有効化


</details>


  </td>
  <td><a href="https://github.com/yohi/dotfiles/pull/12/files#diff-53367e834c8ddf8d1bb47ae3d1998c91b86cd048d5b1c55829f237891d875c93">+90/-48</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dpp.lua</strong><dd><code>ハイライト設定の更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vim/rc/dpp.lua

- ハイライト設定を`vim.api.nvim_set_hl`に置き換え
- 古いハイライト設定をコメントアウト


</details>


  </td>
  <td><a href="https://github.com/yohi/dotfiles/pull/12/files#diff-09c327778f7dd3ecf11d32c763da21f5f41c42ee1e9b2434f4c392f25775f95b">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information